### PR TITLE
Updated Dockerfile for kasvatus-koulutus project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:16.13.2-alpine3.15
 
 WORKDIR /elasticproxy
 
+ENV npm_config_cache=/app/.npm
+
 ENV APP_NAME paatokset-elasticproxy
 
 COPY package*.json ./


### PR DESCRIPTION
Seems like there are issues with kasvatus-koulutus-test environment getting error: 

npm ERR! code EACCES
npm ERR! syscall mkdir
npm ERR! path /.npm
npm ERR! errno -13
npm ERR!
npm ERR! Your cache folder contains root-owned files, due to a bug in
npm ERR! previous versions of npm which has since been addressed.
npm ERR!
npm ERR! To permanently fix this problem, please run:
npm ERR!   sudo chown -R 1002510000:0 "/.npm"


To fix this issue I added this line which fixed the problem

npm_config_cache=/app/.npm